### PR TITLE
Label sections

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -27,6 +27,7 @@ let
     '';
 
   manualXsltprocOptions = toString [
+    "--param section.autolabel 1"
     "--param section.label.includes.component.label 1"
     "--stringparam html.stylesheet style.css"
     "--param xref.with.number.and.title 1"


### PR DESCRIPTION
In the TOC, it currently reads 

```
1. why you should give it try
1.. Introduction
1.. Rationale of pills
```

With this change it reads

```
1. why you should give it try
1.1. Introduction
1.2. Rationale of pills
```